### PR TITLE
update blog name to be text if the blog has not be shared

### DIFF
--- a/docs/_pages/talks.md
+++ b/docs/_pages/talks.md
@@ -18,15 +18,15 @@ Talks from our BOT5 members.
 
 | Seminar | Member | Topic |
 | ------- | ------ | ----- |
-| [S1E11](https://bot5.club/events/seminar-minutes-11/) | [段清华](https://bot5.club/people/qhduan) | [打造一个超越 rasa 的chatbot平台 —— deepdialog.ai](https://www.bot5.club/talks/TBD) |
-| [S1E10](https://bot5.club/events/seminar-minutes-10/) | [彭骏](https://bot5.club/people/github_username) | [如何从0打造7代李白](https://www.bot5.club/talks/TBD) |
-| [S1E9](https://bot5.club/events/seminar-minutes-9/) | [张程](https://bot5.club/people/github_username) | [如何评价Chatbot交互过程中的主观评估指标](https://www.bot5.club/talks/TBD) |
+| [S1E11](https://bot5.club/events/seminar-minutes-11/) | [段清华](https://bot5.club/people/qhduan) | 打造一个超越 rasa 的chatbot平台 —— deepdialog.ai |
+| [S1E10](https://bot5.club/events/seminar-minutes-10/) | [彭骏](https://bot5.club/people/github_username) | 如何从0打造7代李白 |
+| [S1E9](https://bot5.club/events/seminar-minutes-9/) | [张程](https://bot5.club/people/github_username) | 如何评价Chatbot交互过程中的主观评估指标 |
 | [S1E8](https://bot5.club/events/seminar-minutes-8/) | [李佳芮](https://bot5.club/people/lijiarui/) | 基于微信社交流量的 SalesForce |
 | [S1E8](https://bot5.club/events/seminar-minutes-8/) | [朱跃峰](https://bot5.club/people/jeffzhu76/) | Chatbot 阳光商业社群联盟构想 |
 | [S1E7](https://bot5.club/events/seminar-minutes-7/) | [段清华](https://bot5.club/people/qhduan) | 搞定一个对话平台 |
 | [S1E7](https://bot5.club/events/seminar-minutes-7/) | [李卓桓](https://bot5.club/people/huan) | Bot Market Place — 可重用能力平台 |
 | [S1E6](https://www.bot5.club/events/seminar-minutes-6/) | [李卓桓](/people/huan) | [Connect to Wechat: Bot Builder Adapter for Wechat Individual Account](https://www.bot5.club/talks/botbuilder-wechaty-adapter/) |
-| [S1E6](https://bot5.club/events/seminar-minutes-?-?/) | [李靖](https://bot5.club/people/github_username) | [Bot Framework 产品组互动](https://www.bot5.club/talks/TBD) |
+| [S1E6](https://bot5.club/events/seminar-minutes-6/) | [李靖](https://bot5.club/people/github_username) | Bot Framework 产品组互动 |
 | [S1E6](https://bot5.club/events/seminar-minutes-6/) | [丁煜恒](https://bot5.club/people/andrewdyhhub) | [Microsoft Bot Framework 介绍](https://www.bot5.club/talks/microsoft-bot-intro/) |
 | [S1E5](https://www.bot5.club/events/seminar-minutes-5/) | [赵俊良](/people/zhaoic) | [实现支持微信小程序的聊天机器人](https://www.bot5.club/talks/wechaty-send-miniprogram/) |
 | [S1E5](https://www.bot5.club/events/seminar-minutes-5/) | [张玉睿](/people/zhyr) | [如何在微信上做知识管理](https://www.bot5.club/talks/zhyr-km-by-wechat) |


### PR DESCRIPTION
When the user clicked on some link that has no content, it will jump to an empty page, which cause confusion. Let's make those links to blogs that are not created not clickable, thus people browse the page will have all links working.